### PR TITLE
Return to default-exports for components and contexts

### DIFF
--- a/src/components/application.js
+++ b/src/components/application.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import { StaticKitProvider } from '@statickit/react'
 
-import { CookieConsentContext } from '../contexts/cookie-consent'
-import { CookieConsent } from './cookie-consent'
+import CookieConsentContext from '../contexts/cookie-consent'
+import CookieConsent from './cookie-consent'
 
 export default ({ children }) => {
   const [isCookieConsentGiven, setIsCookieConsentGiven] = useState(false)

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export const Button = ({
+const Button = ({
   category,
   children,
   className,
@@ -59,3 +59,5 @@ Button.propTypes = {
 Button.defaultProps = {
   category: 'regular',
 }
+
+export default Button

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -1,6 +1,6 @@
 import React from  'react'
 
-export const Checkbox = ({
+export default ({
   ...props
 }) => {
   return (

--- a/src/components/contact-form.js
+++ b/src/components/contact-form.js
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
 import { useForm, ValidationError } from '@statickit/react'
 
-import { Button } from './button'
-import { Checkbox } from './checkbox'
-import { RequiresCookieConsent } from './requires-cookie-consent'
+import Button from './button'
+import Checkbox from './checkbox'
 import Flash from './flash'
 import Input from './input'
 import Label from './label'
+import RequiresCookieConsent from './requires-cookie-consent'
 import Textarea from './textarea'
 
 export default () => {

--- a/src/components/convertkit-form.js
+++ b/src/components/convertkit-form.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Helmet } from 'react-helmet'
 
-import { Button } from './button'
+import Button from './button'
 import Input from './input'
-import { RequiresCookieConsent } from './requires-cookie-consent'
+import RequiresCookieConsent from './requires-cookie-consent'
 
-export const ConvertkitForm = ({
+export default ({
   cta,
   location,
   svForm,

--- a/src/components/cookie-consent.js
+++ b/src/components/cookie-consent.js
@@ -1,9 +1,9 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 
-import { CookieConsentContext } from '../contexts/cookie-consent'
+import CookieConsentContext from '../contexts/cookie-consent'
 
-export const CookieConsent = () => {
+export default () => {
   const { setIsCookieConsentGiven } = useContext(CookieConsentContext)
 
   const [isCookieSolutionConfigured, setIsCookieSolutionConfigured] = useState(false)
@@ -26,12 +26,12 @@ export const CookieConsent = () => {
         backgroundColor: '#191d27',
         backgroundOverlay: true,
         content: `
-          <div id=\"iubenda-cs-title\">
+          <div id="iubenda-cs-title">
             Cookie notice
           </div>
 
-          <div id=\"iubenda-cs-paragraph\">
-            We and selected partners use cookies or similar technologies as specified in the <a href=\"/privacy-policy/31487586/cookie-policy?an=no&s_ck=false&newmarkup=yes\" class=\"iubenda-cs-cookie-policy-lnk\">cookie policy</a>.
+          <div id="iubenda-cs-paragraph">
+            We and selected partners use cookies or similar technologies as specified in the <a href="/privacy-policy/31487586/cookie-policy?an=no&s_ck=false&newmarkup=yes" class="iubenda-cs-cookie-policy-lnk">cookie policy</a>.
           </div>
         `,
         customizeButtonCaption: 'Learn more',

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { UpdateCookieSettingsTrigger } from './update-cookie-settings-trigger'
+import UpdateCookieSettingsTrigger from './update-cookie-settings-trigger'
 
 export default () => (
   <footer className="align-items-center color-gray-600 flex flex-column padding-vertical-m">

--- a/src/components/mailing-list-signup.js
+++ b/src/components/mailing-list-signup.js
@@ -1,8 +1,10 @@
 import React from 'react'
 
-import { ConvertkitForm } from './convertkit-form'
+import ConvertkitForm from './convertkit-form'
 
-export default ({ sourceUrl }) => (
+export default ({
+  sourceUrl
+}) => (
   <div className="background-color-gray-200 border-radius-xs padding-horizontal-s padding-vertical-s">
     <h1 className="font-size-24-short margin-0 margin-bottom-xs">
       There is more to learn

--- a/src/components/requires-cookie-consent.js
+++ b/src/components/requires-cookie-consent.js
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react'
 
-import { CookieConsentContext } from '../contexts/cookie-consent'
-import { UpdateCookieSettingsTrigger } from './update-cookie-settings-trigger'
+import CookieConsentContext from '../contexts/cookie-consent'
+import UpdateCookieSettingsTrigger from './update-cookie-settings-trigger'
 
-export const RequiresCookieConsent = ({
+export default ({
   className,
   children,
   target,

--- a/src/components/update-cookie-settings-trigger.js
+++ b/src/components/update-cookie-settings-trigger.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { Button } from './button'
-import { CookieIcon } from '../icons/cookie';
+import Button from './button'
+import CookieIcon from '../icons/cookie';
 
-export const UpdateCookieSettingsTrigger = () => (
+export default () => (
   <Button className="iubenda-cs-preferences-link">
     <div className="align-items-center flex">
       <div className="height-24 width-24 margin-right-xxs">

--- a/src/components/video.js
+++ b/src/components/video.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { RequiresCookieConsent } from './requires-cookie-consent'
+import RequiresCookieConsent from './requires-cookie-consent'
 
 export default ({
   title,

--- a/src/contexts/cookie-consent.js
+++ b/src/contexts/cookie-consent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const CookieConsentContext = React.createContext({
+export default React.createContext({
   isCookieConsentGiven: false,
   setIsCookieConsentGiven: () => {}
 })

--- a/src/icons/cookie.js
+++ b/src/icons/cookie.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const CookieIcon = () => (
+export default () => (
   <svg
     width="100%"
     height="100%"

--- a/src/pages/newsletter.js
+++ b/src/pages/newsletter.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { graphql } from 'gatsby';
 
-import { ConvertkitForm } from '../components/convertkit-form'
+import ConvertkitForm from '../components/convertkit-form'
 import Layout from '../components/layout'
 import MetaTags from '../components/meta-tags'
 import NewsletterTeaser from '../components/newsletter-teaser'

--- a/src/templates/course.js
+++ b/src/templates/course.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 
-import { ConvertkitForm } from '../components/convertkit-form'
+import ConvertkitForm from '../components/convertkit-form'
 import Layout from '../components/layout'
 import MetaTags from '../components/meta-tags'
 import RichPreview from '../components/rich-preview'


### PR DESCRIPTION
Deciding to be consistent here. Until there is no good reason to move to named exports, components and contexts will still be exported as default exports.