### PR TITLE
Give directories to read files from in loop

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,12 @@
+const types = [
+  'courses',
+  'firetips',
+  'newsletters',
+  'pages',
+  'posts',
+  'projects'
+]
+
 module.exports = {
   siteMetadata: {
     description: ``,
@@ -12,49 +21,15 @@ module.exports = {
           require('postcss-combine-media-query')()
         ]
       }
-    }, {
+    },
+    ...types.map(name => ({
       resolve: `gatsby-source-filesystem`,
       options: {
         ignore: [`**/\.*`],
-        name: `courses`,
-        path: `${__dirname}/_courses`,
+        name,
+        path: `${__dirname}/_${name}`,
       }
-    }, {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        ignore: [`**/\.*`],
-        name: `firetips`,
-        path: `${__dirname}/_firetips`,
-      }
-    }, {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        ignore: [`**/\.*`],
-        name: `newsletters`,
-        path: `${__dirname}/_newsletters`,
-      }
-    }, {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        ignore: [`**/\.*`],
-        name: `pages`,
-        path: `${__dirname}/_pages`,
-      }
-    }, {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        ignore: [`**/\.*`],
-        name: `projects`,
-        path: `${__dirname}/_projects`,
-      }
-    }, {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        ignore: [`**/\.*`],
-        name: `posts`,
-        path: `${__dirname}/_posts`,
-      }
-    }, {
+    })), {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [


### PR DESCRIPTION
Instead of repeating the same object over and over again per content
type, we can give an array that Gatsby then loops over.